### PR TITLE
Fixed burning bug on Alloyer and Crusher GUI [#25]

### DIFF
--- a/src/main/java/it/hurts/metallurgy_5/item/tool/ItemHoeBase.java
+++ b/src/main/java/it/hurts/metallurgy_5/item/tool/ItemHoeBase.java
@@ -24,7 +24,7 @@ public class ItemHoeBase extends ItemHoe {
     public ItemHoeBase(ToolMaterial material, String name)
     {
         super(material);
-        setUnlocalizedName(name)
+        setUnlocalizedName(name);
         setRegistryName(name);
         this.name = name;
         setCreativeTab(MetallurgyTabs.tabTool);

--- a/src/main/java/it/hurts/metallurgy_5/tileentity/TileEntityAlloyer.java
+++ b/src/main/java/it/hurts/metallurgy_5/tileentity/TileEntityAlloyer.java
@@ -232,7 +232,7 @@ public class TileEntityAlloyer extends TileEntityLockable implements ITickable, 
         this.burnTime = compound.getInteger("burn_time");
         this.alloyingTime = compound.getInteger("alloying_time");
         this.totalAlloyingTime = compound.getInteger("total_alloying_time");
-        this.currentBurnTime = getItemBurnTime(this.inventory.get(1));
+        this.currentBurnTime = compound.getInteger("current_burn_time");
 
         if(compound.hasKey("CustomName", 8)) 
             this.setCustomName(compound.getString("CustomName"));
@@ -247,6 +247,7 @@ public class TileEntityAlloyer extends TileEntityLockable implements ITickable, 
         super.writeToNBT(compound); //Ripeto che non lo ricordo
         compound.setInteger("burn_time", (short)this.burnTime); //Impostiamo il BurnTime ma con meno bit possibili(lo compressiamo)
         compound.setInteger("alloying_time", (short)this.alloyingTime);//Impostiamo il AlloyingTime ma con meno bit possibili(lo compressiamo)
+        compound.setInteger("current_burn_time", (short)this.currentBurnTime);//Impostiamo il BurnTime ma con meno bit possibili(lo compressiamo)
         compound.setInteger("total_alloying_time", (short)this.totalAlloyingTime);//Impostiamo il AlloyingTime totale ma con meno bit possibili(lo compressiamo)
         ItemStackHelper.saveAllItems(compound, this.inventory);
 

--- a/src/main/java/it/hurts/metallurgy_5/tileentity/TileEntityCrusher.java
+++ b/src/main/java/it/hurts/metallurgy_5/tileentity/TileEntityCrusher.java
@@ -217,7 +217,7 @@ public class TileEntityCrusher extends TileEntityLockable implements ITickable, 
         this.burnTime = compound.getInteger("burn_time");
         this.crushTime = compound.getInteger("crush_time");
         this.totalCrushTime = compound.getInteger("total_crush_time");
-        this.currentBurnTime = getItemBurnTime(this.inventory.get(1));
+        this.currentBurnTime = compound.getInteger("current_burn_time");
 
         if (compound.hasKey("CustomName", 8))
             this.setCustomName(compound.getString("CustomName"));
@@ -229,6 +229,7 @@ public class TileEntityCrusher extends TileEntityLockable implements ITickable, 
     public NBTTagCompound writeToNBT(NBTTagCompound compound) {
         super.writeToNBT(compound);
         compound.setInteger("burn_time", (short) this.burnTime);
+        compound.setInteger("current_burn_time", (short) this.currentBurnTime);
         compound.setInteger("crush_time", (short) this.crushTime);
         compound.setInteger("total_crush_time", (short) this.totalCrushTime);
         ItemStackHelper.saveAllItems(compound, this.inventory);


### PR DESCRIPTION
This is a:
 *Code Pull request
**Description of the pull request content:**
This bug was caused by the `getItemBurnTime` in the method `readFromNBT` that gave the value 0 and  consequently the Tile's GUI method `getBurnLeftScaled` gave a wrong proportion of the texture height