### PR TITLE
Fixed Sword Potion Effect bug

### DIFF
--- a/src/main/java/it/hurts/metallurgy_5/util/handler/EventHandler.java
+++ b/src/main/java/it/hurts/metallurgy_5/util/handler/EventHandler.java
@@ -175,7 +175,9 @@ public class EventHandler {
 	public static void onAttack(AttackEntityEvent event){
 
 		EntityPlayer player = event.getEntityPlayer();
-	
+		if(!player.world.isRemote)
+		{
+		
 //		Shadow Iron Sword (Blindness [cecità])
 		if (player.getHeldItemMainhand().isItemEqualIgnoreDurability(new ItemStack(ModTools.shadow_iron_sword)))
 		{
@@ -218,12 +220,14 @@ public class EventHandler {
 				((EntityLivingBase) foe).addPotionEffect(new PotionEffect(MobEffects.WITHER, 60,1));
 		}
 		
+		
 //		kalendrite sword (Regeneration)
 		if (player.getHeldItemMainhand().isItemEqualIgnoreDurability(new ItemStack(ModTools.kalendrite_sword))) {
 			
 			if((int)(Math.random()*100) <= 30)
 				player.addPotionEffect(new PotionEffect(MobEffects.REGENERATION, 100, 1));
 		}
+		
 		
 //		TODO migliorare questo effetto
 //		Sanguinite Sword (Vampirism)
@@ -264,6 +268,7 @@ public class EventHandler {
 						player.addPotionEffect(new PotionEffect(MobEffects.REGENERATION, 60, 4));
 				}
 			}
+		}
 		}
 	}
 	


### PR DESCRIPTION

* Code Pull request

---Description of the pull request content:

The client sword effect in the GUI remained even after 0 seconds,because the boolean `isRemote` is the player world was not checked
![2018-11-22_16 35 38](https://user-images.githubusercontent.com/45203064/48912679-8d5c7b00-ee76-11e8-8d33-8c9a2182376a.png)
![2018-11-22_16 35 44](https://user-images.githubusercontent.com/45203064/48912681-8d5c7b00-ee76-11e8-822f-6a47b5361335.png)


